### PR TITLE
chore: add local Flask setup guide (#7)

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,33 @@
+# Local Flask Setup Guide
+
+This guide documents how I set up and ran the Flask app locally using Python 3.11.
+
+---
+
+## 🧰 Requirements
+
+- Python 3.11 (installed via Homebrew)
+- pip
+- virtualenv
+
+---
+
+## 🧪 Steps
+
+1. Clone the repo
+   ```bash
+   git clone https://github.com/smritirangarajan/portfolio.git
+   cd portfolio
+2. Create and activate a virtual environment
+    ```bash
+    python3.11 -m venv venv
+    source venv/bin/activate
+3. Install project dependencies
+    ```bash
+    pip install --upgrade pip
+    pip install -r requirements.txt
+4. Run the Flask development server
+    ```bash
+    export FLASK_ENV=development
+    flask run
+


### PR DESCRIPTION
This PR adds a local setup guide for the Flask app under `docs/setup.md`.

### Changes
- Created `docs/setup.md`
- Documented steps to set up and run the Flask app locally using Python 3.11, virtualenv, and pip

### Manual Test
I followed the documented steps and successfully launched the app at `http://127.0.0.1:5000`.

### Linked Issue
Closes #7

### Checklist
- [7] Issue linked
- [7] Steps tested manually
- [7] `.md` file renders correctly on GitHub
- [7] No secrets committed
