### PR TITLE
feat: add About Me section to homepage (#2)

### DIFF
--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -95,3 +95,35 @@ body {
     font-size: 50px;
     font-weight: 700;
 }
+
+.about {
+    background-color: #f5f5f9; /* matches body bg */
+    padding: 30px 20px;
+    text-align: center;
+  }
+
+  .about-title {
+    color: #1d539f;
+    font-size: 28px;
+    font-weight: 700;
+    margin-bottom: 20px;
+  }
+  
+  .about-container {
+    max-width: 900px;
+    margin: 0 auto;
+    font-size: 18px;
+    color: #333;
+    font-family: "Roboto", sans-serif;
+    line-height: 1.6;
+  }
+  
+  .about-container a {
+    color: #1d539f;
+    font-weight: 600;
+    text-decoration: none;
+  }
+  
+  .about-container a:hover {
+    text-decoration: underline;
+  }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -36,5 +36,14 @@
         </div>
         <h1>{{ title }}</h1>
     </div>
+    <section class="about">
+        <h2 class="about-title">About Me</h2>
+        <div class="about-container">
+          <p>
+            Hi! I'm Smriti, a student at UC Berkeley studying Data Science and Computer Science. At Berkeley, I'm involved in the Mock Trial Team as an attorney and a member of Women in Computing and Data Science. I'm part of the META and MLH Summer Production Engineering Fellowship, where I'm deepening my skills in systems and infrastructure. I’m passionate about building robust, real-world tech solutions that create social impact. Currently, I’m working as a Data Science Intern at a non-profit organization, where I’m using data to drive meaningful decision-making. Previously, I interned at a Y Combinator startup and supported early-stage founders at the Berkeley SkyDeck Accelerator. In my free time, I enjoy gardening, playing piano, and finding creative ways to blend technology with everyday life. Feel free to connect with me
+            <a href="https://www.linkedin.com/in/smriti-rangarajan/" target="_blank">here</a>.
+          </p>
+        </div>
+      </section>
 </body>
 </html>


### PR DESCRIPTION
### Summary
This PR adds a personalized “About Me” section to the homepage.

### Changes
- Added a new section below the profile image in `index.html`
- Styled the section in `main.css` to match the existing layout and typography
- Includes a LinkedIn link

### Linked Issue
Closes #2