### PR TITLE
feat: add base Jinja templates (#8)

### DIFF
--- a/app/static/styles/card.css
+++ b/app/static/styles/card.css
@@ -1,0 +1,41 @@
+body {
+    background-color: #001F3F;
+    font-family: 'Roboto', sans-serif;
+    margin: 0;
+    padding: 0;
+  }
+  
+  .container {
+    max-width: 900px;
+    margin: 40px auto;
+    padding: 0 20px;
+  }
+  
+  .card {
+    background-color: #ffffff;
+    border-radius: 20px;
+    padding: 30px;
+    margin-bottom: 30px;
+    text-align: center;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+  }
+  
+  .card img {
+    width: 200px;
+    height: 200px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-bottom: 20px;
+  }
+  
+  .card h3 {
+    margin: 0;
+    color: #003366;
+    font-size: 24px;
+  }
+  
+  .card p {
+    font-size: 18px;
+    color: #666;
+  }
+  

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ title or "My Portfolio" }}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='./static/styles/jinja.css') }}">
+</head>
+<body>
+  <div class="container">
+    {% block content %}
+    {% endblock %}
+  </div>
+</body>
+</html>
+

--- a/app/templates/macros.html
+++ b/app/templates/macros.html
@@ -1,0 +1,7 @@
+{% macro card(img, header, subtitle) %}
+  <div class="card">
+    <img src="{{ url_for('static', filename=img) }}" alt="{{ header }}">
+    <h3>{{ header }}</h3>
+    <p>{{ subtitle }}</p>
+  </div>
+{% endmacro %}


### PR DESCRIPTION
### Summary
Sets up Jinja templating with:
- `base.html` layout
- `macros.html` reusable card component
- `card.css` for card styling

### Linked Issue
Closes #8 